### PR TITLE
fix Windows: normalize slashes in paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ MarkdownResolver.prototype.readDirectory = function(srcPath, allFiles) {
 
     let existingTreeNode = Array.prototype.find.call(tree, (file, i) => {
       index = i;
-      return file.path === relativePath;
+      return this.normalizeSlashes(file.path) === relativePath;
     });
 
     if (existingTreeNode) {
@@ -62,7 +62,11 @@ MarkdownResolver.prototype.readDirectory = function(srcPath, allFiles) {
 
 MarkdownResolver.prototype.relativePath = function(srcDir) {
   let relPath = srcDir.replace(this.options.basePath, '');
-  return relPath.replace(/^\/|\/$/g, '');
+  return this.normalizeSlashes(relPath).replace(/^\/|\/$/g, '');
+}
+
+MarkdownResolver.prototype.normalizeSlashes = function(path) {
+  return path.replace(/\\/g, '/');
 }
 
 MarkdownResolver.prototype.build = function() {


### PR DESCRIPTION
Background: `ember-cli-markdown-resolver` can't find any files when building on Windows, since Node.js's `fs` operations spit out file paths with backslashes, while the resolver expects the paths to have forward-slashes.

This PR simply normalizes the slashes, so Windows behaves like the rest of the sane world. ;)
